### PR TITLE
actions/upload-artifactをv4に更新

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
           publish_branch: gh-pages
 
       - name: Upload Archive
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: gh-pages
           path: public


### PR DESCRIPTION
https://github.com/yamacraft/yamacraft.github.io/actions/runs/12292092555/job/34302039904

> Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v1`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

ということなので、v4に更新。
https://github.com/actions/upload-artifact